### PR TITLE
feat: Optimize EMIT UI and behavior for Embed Mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "d3": "^7.9.0",
     "luxon": "^3.5.0",
     "mapbox-gl": "^3.7.0",
-    "mapboxgl-timeline": "^1.0.2",
+    "mapboxgl-timeline": "1.0.2",
     "moment": "^2.30.1",
     "react-loader-spinner": "^6.1.6",
     "react-resizable-panels": "^2.1.1",

--- a/src/App.css
+++ b/src/App.css
@@ -71,4 +71,6 @@ body,
 
 :root {
   --main-grey: #252525;
+  --light-grey: #f5f5f5;
+  --ghg-indigo: #3e4ded;
 }

--- a/src/components/map/itemAnimation/index.jsx
+++ b/src/components/map/itemAnimation/index.jsx
@@ -10,7 +10,7 @@ import {
   sourceExists,
 } from '../utils';
 
-import 'mapboxgl-timeline/dist/style.css';
+import 'mapboxgl-timeline/dist/mapboxgl-timeline.css';
 import './index.css';
 /*
       Animation component for the visualization layers

--- a/src/components/map/itemAnimation/index.jsx
+++ b/src/components/map/itemAnimation/index.jsx
@@ -10,7 +10,7 @@ import {
   sourceExists,
 } from '../utils';
 
-import 'mapboxgl-timeline/dist/mapboxgl-timeline.css';
+import 'mapboxgl-timeline/dist/style.css';
 import './index.css';
 /*
       Animation component for the visualization layers

--- a/src/components/map/mapControls/hamburger.jsx
+++ b/src/components/map/mapControls/hamburger.jsx
@@ -11,15 +11,22 @@ import MenuIcon from '@mui/icons-material/Menu';
  *
  * @param {Object} props
  * @param {Function} props.onClickHandler - Function to call when the icon is clicked.
+ * @param {boolean} props.isActive - Whether the drawer is currently active/open.
  * @returns {JSX.Element} MUI IconButton wrapped in a tooltip.
  */
 
-function HamburgerIcon({ onClickHandler }) {
+function HamburgerIcon({ onClickHandler, isActive }) {
   return (
-    <Tooltip title='Toggle Drawer'>
-      <IconButton className='menu-open-icon' onClick={onClickHandler}>
-        <MenuIcon className='map-control-icon'  sx={{ color: '#2d2d2d' }}/>
-      </IconButton>
+    <Tooltip title={isActive ? 'Toggle Drawer' : 'Drawer unavailable'}>
+      <span>
+        <IconButton
+          className='menu-open-icon'
+          onClick={onClickHandler}
+          disabled={!isActive}
+        >
+          <MenuIcon className='map-control-icon' sx={{ color: isActive ? '#2d2d2d' : '#888' }}/>
+        </IconButton>
+      </span>
     </Tooltip>
   );
 }
@@ -36,9 +43,11 @@ function HamburgerIcon({ onClickHandler }) {
 export class HamburgerControl {
   /**
    * @param {Function} onHamburgerClick - Callback triggered when the icon is clicked.
+   * @param {boolean} drawerActive - Whether the drawer is currently active/open.
    */
-  constructor(onHamburgerClick) {
+  constructor(onHamburgerClick, drawerActive) {
     this._onClick = onHamburgerClick;
+    this._drawerActive = drawerActive;
     this.root = null;
     this.isMounted = true;
   }
@@ -55,9 +64,22 @@ export class HamburgerControl {
     this._container = document.createElement('div');
     this._container.className = 'mapboxgl-ctrl mapboxgl-ctrl-group';
     const root = ReactDOM.createRoot(this._container);
-    root.render(<HamburgerIcon onClickHandler={this._onClick} />);
+    root.render(<HamburgerIcon onClickHandler={this._onClick} isActive={this._drawerActive} />);
     this.root = root;
     return this._container;
+  }
+
+  /**
+   * Update the control with new drawer active state.
+   * Re-renders the React component with updated props.
+   *
+   * @param {boolean} drawerActive - New drawer active state.
+   */
+  update(drawerActive) {
+    this._drawerActive = drawerActive;
+    if (this.root && this.isMounted) {
+      this.root.render(<HamburgerIcon onClickHandler={this._onClick} isActive={this._drawerActive} />);
+    }
   }
 
   /**

--- a/src/components/map/mapControls/index.jsx
+++ b/src/components/map/mapControls/index.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import mapboxgl from 'mapbox-gl';
 import { useMapbox } from '../../../context/mapContext';
 import { HamburgerControl } from './hamburger';
@@ -42,6 +42,7 @@ const scaleUnits = {
  */
 
 const DefaultMapControls = ({
+  isDrawerActive,
   measureMode,
   onClickHamburger,
   onClickMeasureMode,
@@ -53,6 +54,7 @@ const DefaultMapControls = ({
 }) => {
   const { map } = useMapbox();
   const customControlContainer = useRef();
+  const hamburgerControlRef = useRef();
   const [drawerWidth, setDrawerWidth] = useState(0);
 
   /**
@@ -84,13 +86,24 @@ const DefaultMapControls = ({
     };
   }, [openDrawer]);
 
+  const onClickHamburgerRef = useRef(onClickHamburger);
+
+  useEffect(() => {
+    onClickHamburgerRef.current = onClickHamburger;
+  }, [onClickHamburger]);
+
   /**
    * Setup static controls (hamburger, home, nav, visibility).
    */
   useEffect(() => {
     if (!map) return;
 
-    const hamburgerControl = new HamburgerControl(onClickHamburger);
+    const hamburgerControl = new HamburgerControl(() =>
+      onClickHamburgerRef.current(),
+      isDrawerActive
+    );
+    hamburgerControlRef.current = hamburgerControl;
+
     const mapboxNavigation = new mapboxgl.NavigationControl({
       showCompass: false,
     });
@@ -116,8 +129,18 @@ const DefaultMapControls = ({
       if (mapboxNavigation) mapboxNavigation.onRemove();
       if (layerVisibilityControl) layerVisibilityControl.onRemove();
       if (homeControl) homeControl.onRemove();
+      hamburgerControlRef.current = null;
     };
   }, [map]);
+
+  /**
+   * Update hamburger control when drawer active state changes.
+   */
+  useEffect(() => {
+    if (hamburgerControlRef.current) {
+      hamburgerControlRef.current.update(isDrawerActive);
+    }
+  }, [isDrawerActive]);
 
   /**
    * Add the measurement tool control.
@@ -223,6 +246,7 @@ const DefaultMapControls = ({
  */
 
 export const MapControls = ({
+  isDrawerActive,
   openDrawer,
   setOpenDrawer,
   handleResetHome,
@@ -232,14 +256,17 @@ export const MapControls = ({
   const [clearMeasurementIcon, setClearMeasurementIcon] = useState(false);
   const [clearMeasurementLayer, setClearMeasurementLayer] = useState(false);
   const [mapScaleUnit, setMapScaleUnit] = useState(scaleUnits.MILES);
+  const handleHamburgerClick = useCallback(() => {
+    setOpenDrawer(!openDrawer);
+  }, [openDrawer, setOpenDrawer]);
+
   return (
     <>
       <DefaultMapControls
+        isDrawerActive={isDrawerActive}
         openDrawer={openDrawer}
         measureMode={measureMode}
-        onClickHamburger={() => {
-          setOpenDrawer((openDrawer) => !openDrawer);
-        }}
+        onClickHamburger={handleHamburgerClick}
         onClickMeasureMode={() => {
           setMeasureMode((measureMode) => !measureMode);
         }}

--- a/src/components/map/mapControls/index.jsx
+++ b/src/components/map/mapControls/index.jsx
@@ -53,6 +53,36 @@ const DefaultMapControls = ({
 }) => {
   const { map } = useMapbox();
   const customControlContainer = useRef();
+  const [drawerWidth, setDrawerWidth] = useState(0);
+
+  /**
+   * Measure the persistent drawer width to calculate dynamic positioning
+   */
+  useEffect(() => {
+    const measureDrawerWidth = () => {
+      // Measure drawer width
+      const drawerElement = document.querySelector('.MuiDrawer-paper');
+      if (drawerElement && openDrawer) {
+        setDrawerWidth(drawerElement.offsetWidth);
+      } else {
+        setDrawerWidth(0);
+      }
+    };
+
+    // Initial measurement
+    measureDrawerWidth();
+
+    // Remeasure on window resize
+    window.addEventListener('resize', measureDrawerWidth);
+
+    // Use a small timeout to ensure drawer transition completes
+    const timeoutId = setTimeout(measureDrawerWidth, 300);
+
+    return () => {
+      window.removeEventListener('resize', measureDrawerWidth);
+      clearTimeout(timeoutId);
+    };
+  }, [openDrawer]);
 
   /**
    * Setup static controls (hamburger, home, nav, visibility).
@@ -163,11 +193,16 @@ const DefaultMapControls = ({
     };
   }, [map, mapScaleUnit, measureMode]);
 
+  // Calculate dynamic right position: drawer width + 10px gap
+  const rightPosition = openDrawer && drawerWidth > 0
+    ? `${drawerWidth + 10}px`
+    : '0.5rem';
+
   return (
     <div
       id='mapbox-custom-controls'
       ref={customControlContainer}
-      style={{ right: openDrawer ? '30.7rem' : '0.5rem' }}
+      style={{ right: rightPosition }}
     ></div>
   );
 };

--- a/src/components/map/mapMarker/index.jsx
+++ b/src/components/map/mapMarker/index.jsx
@@ -34,12 +34,12 @@ export const MarkerFeature = ({ items, onSelectVizItem, getPopupContent }) => {
 
       const { coordinates, id } = item;
       const { lon, lat } = coordinates;
-      const markerColor = '#00b7eb';
+      const markerColor = '#61baf1ff';
+      const strokeColor = '#1d577aff';
 
       const el = document.createElement('div');
       el.className = 'marker';
-      el.innerHTML = getMarkerSVG(markerColor);
-
+      el.innerHTML = getMarkerSVG(markerColor, strokeColor);
       const marker = new mapboxgl.Marker({ element: el, anchor: 'top' }).setLngLat([lon, lat]);
 
       const popup = getPopupContent
@@ -120,7 +120,7 @@ const getMarkerSVG = (color, strokeColor = '#000000') => {
   return `
     <svg fill="${color}" width="30px" height="30px" viewBox="-51.2 -51.2 614.40 614.40" xmlns="http://www.w3.org/2000/svg">
       <g id="SVGRepo_bgCarrier" stroke-width="0"></g>
-      <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round" stroke="${strokeColor}" stroke-width="10.24">
+      <g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round" stroke="${strokeColor}" stroke-width="20.24">
         <path d="M172.268 501.67C26.97 291.031 0 269.413 0 192 0 85.961 85.961 0 192 0s192 85.961 192 192c0 77.413-26.97 99.031-172.268 309.67-9.535 13.774-29.93 13.773-39.464 0zM192 272c44.183 0 80-35.817 80-80s-35.817-80-80-80-80 35.817-80 80 35.817 80 80 80z"></path>
       </g>
       <g id="SVGRepo_iconCarrier">

--- a/src/components/map/mapZoom/index.jsx
+++ b/src/components/map/mapZoom/index.jsx
@@ -2,6 +2,8 @@ import { useEffect } from 'react';
 
 import { useMapbox } from '../../../context/mapContext';
 
+const DEFAULT_ZOOM_LEVEL = 8.5;
+
 /**
  * MapZoom Component
  *
@@ -18,13 +20,12 @@ export const MapZoom = ({ zoomLocation, zoomLevel }) => {
   const { map } = useMapbox();
 
   useEffect(() => {
-    if (!map || !zoomLocation.length) return;
+    if (!map || !zoomLocation?.length) return;
 
     const [lon, lat] = zoomLocation;
     map.flyTo({
-      center: [lon, lat], // Replace with the desired latitude and longitude
-      offset: zoomLevel ? [0, 0] : [-250, 0],
-      zoom: zoomLevel ? zoomLevel : 8.5,
+      center: [lon, lat],
+      zoom: zoomLevel ?? DEFAULT_ZOOM_LEVEL,
     });
   }, [map, zoomLevel, zoomLocation]);
 

--- a/src/components/method/filter/index.jsx
+++ b/src/components/method/filter/index.jsx
@@ -102,7 +102,7 @@ export function FilterByDate({ onDateChange, filterDateRange }) {
         <div
           style={{
             display: 'flex',
-            margin: '-4px',
+            margin: '2px',
             fontFamily: "Public sans",
             color: "#808080",
             fontSize: "14px",
@@ -116,6 +116,7 @@ export function FilterByDate({ onDateChange, filterDateRange }) {
               marginBottom: '0px',
               display: 'flex',
               justifyContent: 'center',
+              fontSize: "12px",
             }}
           >
             Start Date
@@ -128,6 +129,7 @@ export function FilterByDate({ onDateChange, filterDateRange }) {
 
               display: 'flex',
               justifyContent: 'center',
+              fontSize: "12px",
             }}
           >
             End Date

--- a/src/components/method/search/index.jsx
+++ b/src/components/method/search/index.jsx
@@ -92,6 +92,24 @@ export function Search({ vizItems, onSelectedVizItemSearch, setFromSearch }) {
         if (typeof option === 'string' || typeof value === 'string') return option === value
         return option.id === value.id && option.value === value.value
       }}
+      componentsProps={{
+        popper: {
+          style: { zIndex: 1002 }
+        },
+        paper: {
+          sx: {
+            backgroundColor: '#FFFFFF',
+            color: 'grey',
+            fontSize: '13px',
+            '& .MuiAutocomplete-option': {
+              fontSize: '13px',
+              minHeight: 'auto',
+              padding: '4px 8px',
+              color: 'grey'
+            }
+          }
+        }
+      }}
       style={{ width: '100%' }}
       renderInput={(params) => (
         <TextField
@@ -109,7 +127,11 @@ export function Search({ vizItems, onSelectedVizItemSearch, setFromSearch }) {
             ...params.InputProps,
             endAdornment: (
               <>
-                <InputAdornment position='end'>
+                <InputAdornment
+                  position='end'
+                  sx={{
+                    color: 'grey !important',
+                  }}>
                   <SearchIcon />
                 </InputAdornment>
                 {params.InputProps.endAdornment}
@@ -121,6 +143,7 @@ export function Search({ vizItems, onSelectedVizItemSearch, setFromSearch }) {
           }}
           sx={{
             "& .MuiOutlinedInput-root": {
+              fontSize: "13px",
               "& fieldset": {
                 borderColor: "grey !important"
               },

--- a/src/components/method/search/index.jsx
+++ b/src/components/method/search/index.jsx
@@ -117,7 +117,7 @@ export function Search({ vizItems, onSelectedVizItemSearch, setFromSearch }) {
             ),
           }}
           InputLabelProps={{
-            style: { color: 'grey !important' },
+            style: { color: 'grey !important', fontSize: '13px' },
           }}
           sx={{
             "& .MuiOutlinedInput-root": {

--- a/src/components/method/search/index.jsx
+++ b/src/components/method/search/index.jsx
@@ -94,7 +94,7 @@ export function Search({ vizItems, onSelectedVizItemSearch, setFromSearch }) {
       }}
       componentsProps={{
         popper: {
-          style: { zIndex: 1002 }
+          style: { zIndex: 10002 }
         },
         paper: {
           sx: {

--- a/src/components/method/search/index.jsx
+++ b/src/components/method/search/index.jsx
@@ -99,7 +99,11 @@ export function Search({ vizItems, onSelectedVizItemSearch, setFromSearch }) {
           id='outlined-basic'
           label='Search by Plume ID or Location'
           variant='outlined'
-          style={{ width: '100%', backgroundColor: '#EEEEEE' }}
+          size="small"
+          style={{
+            width: '100%',
+            backgroundColor: '#FFFFFF',
+          }}
           onChange={handleOnInputTextChange}
           InputProps={{
             ...params.InputProps,

--- a/src/components/ui/card/index.css
+++ b/src/components/ui/card/index.css
@@ -19,7 +19,7 @@
 .responsive-card {
   display: flex;
   flex-direction: row;
-  margin: 15px 0;
+  margin: 0 0 15px 0;
   gap: 10px;
 }
 

--- a/src/components/ui/card/index.css
+++ b/src/components/ui/card/index.css
@@ -6,6 +6,26 @@
   text-decoration: none;
 }
 
-.card-download-link > div {
+.card-download-link>div {
   color: #0098d7;
+  font-size: 12px;
+}
+
+.card-container {
+  container-type: inline-size;
+  container-name: card;
+}
+
+.responsive-card {
+  display: flex;
+  flex-direction: row;
+  margin: 15px 0;
+  gap: 10px;
+}
+
+/* Stack image on top when card width is below 500px */
+@container card (max-width: 400px) {
+  .responsive-card {
+    flex-direction: column;
+  }
 }

--- a/src/components/ui/card/index.css
+++ b/src/components/ui/card/index.css
@@ -7,7 +7,7 @@
 }
 
 .card-download-link>div {
-  color: #0098d7;
+  color: var(--ghg-indigo);
   font-size: 12px;
 }
 

--- a/src/components/ui/card/index.jsx
+++ b/src/components/ui/card/index.jsx
@@ -29,7 +29,7 @@ const HighlightableCard = styled(Card)`
   }
   border: ${(props) =>
     //eslint-disable-next-line prettier/prettier
-    props.$isHovered ? '1px solid blue' : '1px solid transparent'};
+    props.$isHovered ? '1px solid #4866ff' : '1px solid transparent'};
   box-shadow: ${(props) =>
     //eslint-disable-next-line prettier/prettier
     props.$isHovered ? '0 4px 20px rgba(0, 0, 0, 0.2)' : 'none'};

--- a/src/components/ui/card/index.jsx
+++ b/src/components/ui/card/index.jsx
@@ -13,7 +13,6 @@ import { useConfig } from '../../../context/configContext';
 
 const HorizontalLayout = styled.div`
   width: 100%;
-  max-width:92%;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -48,7 +47,7 @@ const CaptionValue = ({ caption, value, className }) => {
           fontWeight: 500,
           unicodeBidi: 'isolate',
           fontFamily: "Public sans",
-          fontSize: 14,
+          fontSize: 11,
           lineHeight: 1.2,
         }}
       >
@@ -59,7 +58,7 @@ const CaptionValue = ({ caption, value, className }) => {
         variant='body2'
         component='div'
         sx={{
-          color: '#808080',
+          color: 'var(--main-grey)',
           fontSize: 13,
           wordWrap: 'break-word',
           overflowWrap: 'break-word',
@@ -131,20 +130,30 @@ export const VisualizationItemCard = forwardRef(
       if (hoveredVizItemId !== vizItemSourceId) setIsHovered(false);
     }, [hoveredVizItemId, vizItemSourceId]);
     return (
-      <div style={{ width: "100%", maxWidth: "96%" }} ref={ref}>
+      <div
+        className="card-container"
+        style={{
+          width: "100%",
+          maxWidth: "94%",
+          marginLeft: "auto",
+          marginRight: "auto"
+        }}
+        ref={ref}
+      >
         <HighlightableCard
-          sx={{ display: 'flex', flex: '0 0 auto', margin: '15px', width: "100%" }}
+          className="responsive-card"
           onClick={handleCardClick}
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
           $isHovered={isHovered}
         >
           <div
+            className="card-image-container"
             style={{
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              width: "100%"
+              flexShrink: 0
             }}
           >
             <CardMedia
@@ -161,12 +170,20 @@ export const VisualizationItemCard = forwardRef(
             />
           </div>
 
-          <Box sx={{ display: 'flex', flexDirection: 'column', fontFamily: "Sans", width: '100%' }}>
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              fontFamily: "Sans",
+              flex: 1,
+              minWidth: 0
+            }}
+          >
             <CardContent sx={{ flex: '1 0 auto', width: "100%", overflow: "hidden", maxWidth: "100%" }}>
               <HorizontalLayout>
                 <CaptionValue
                   className='card-plume'
-                  caption='ID:'
+                  caption='ID'
                   value={vizItemSourceId}
                 />
                 <CaptionValue
@@ -195,36 +212,36 @@ export const VisualizationItemCard = forwardRef(
               <HorizontalLayout>
                 <CaptionValue
                   className='card-plume'
-                  caption='Location:'
+                  caption='Location'
                   value={location}
                 />
                 <CaptionValue
                   className='card-plume'
-                  caption='UTC Time Observed:'
+                  caption='UTC Time Observed'
                   value={utcTimeObserved}
                 />
               </HorizontalLayout>
               <HorizontalLayout>
                 <CaptionValue
                   className='card-plume'
-                  caption='Max Plume Concentration:'
+                  caption='Max Plume Concentration'
                   value={maxPlumeConcentration + ' ppm m'}
                 />
                 <CaptionValue
                   className='card-plume'
-                  caption='Concentration Uncertainity:'
+                  caption='Concentration Uncertainity'
                   value={concentrationUncertanity + ' ppm m'}
                 />
               </HorizontalLayout>
               <HorizontalLayout>
                 <CaptionValue
                   className='card-plume'
-                  caption='Latitude (Max Conc):'
+                  caption='Latitude (Max Conc)'
                   value={Number(latitudeOfMaxConcentration).toFixed(3)}
                 />
                 <CaptionValue
                   className='card-plume'
-                  caption='Longitude (Max Conc):'
+                  caption='Longitude (Max Conc)'
                   value={Number(longitudeOfMaxConcentration).toFixed(3)}
                 />
 

--- a/src/components/ui/colorBar/helper/index.js
+++ b/src/components/ui/colorBar/helper/index.js
@@ -31,17 +31,23 @@ export const createColorbar = (colorbar, VMIN, VMAX, STEP, colormap) => {
     .scaleSequential(COLOR_MAP[colormap])
     .domain([VMIN, VMAX]); // Set VMIN and VMAX as your desired min and max values
 
+  const numSegments = 100;
+  const segmentData = d3.range(VMIN, VMAX, (VMAX - VMIN) / numSegments);
+  const segmentWidthPercent = 100 / numSegments; // Each segment as percentage
+
   colorbar
     .append('svg')
     .attr('class', 'colorbar-svg')
+    .attr('preserveAspectRatio', 'none')
+    .attr('viewBox', '0 0 100 12')
     .append('g')
     .selectAll('rect')
-    .data(d3.range(VMIN, VMAX, (VMAX - VMIN) / 100)) // Adjust the number of color segments as needed
+    .data(segmentData)
     .enter()
     .append('rect')
-    .attr('height', 12) // height of the svg color segment portion
-    .attr('width', '100%') // Adjust the width of each color segment
-    .attr('x', (d, i) => i * 3)
+    .attr('height', 12)
+    .attr('width', '100%')
+    .attr('x', (_, i) => i * segmentWidthPercent)
     .attr('fill', (d) => colorScale(d));
 
   // Define custom scale labels

--- a/src/components/ui/colorBar/index.css
+++ b/src/components/ui/colorBar/index.css
@@ -1,16 +1,17 @@
 :root {
-  --colorbar-height: 7rem; /* Adjust this value to match your d2 height */
+  --colorbar-height: 5rem; /* Adjust this value to match your d2 height */
 }
 
 #colorbar {
   position: absolute;
-  bottom: 3%;
+  bottom: 5px;
   right: 5px;
   height: var(--colorbar-height);
-  width: 30rem;
+  width: 25vw;
+  min-width: 300px;
   z-index: 10000;
   background-color: white;
-  padding: 1rem;
+  padding: 0.75rem;
   display: flex;
   flex-direction: column;
   justify-content: space-around;
@@ -18,18 +19,19 @@
 
 .colorbar-svg {
   height: 1rem;
-  width: 28rem; /* this will define the colorbar width, make it a bit small than container */
+  width: 100%; /* Dynamic width - scales with container */
 }
 
 .colorbar-scale {
   text-align: center;
+  width: 100%;
 }
 
 .colorbar-label {
   text-align: center;
   margin-bottom: 0px;
-  fontsize: 14px;
-  font-family: Public sans;
+  font-size: 14px;
+  font-family: 'Public Sans';
   color: grey !important;
 }
 

--- a/src/components/ui/drawer/index.css
+++ b/src/components/ui/drawer/index.css
@@ -3,6 +3,7 @@
   text-align: center;
   border-bottom: 2px solid var(--main-grey);
   margin: 0 0.9rem;
+  margin-bottom: 0.9rem;
 }
 
 .drawer-head-content {

--- a/src/components/ui/drawer/index.jsx
+++ b/src/components/ui/drawer/index.jsx
@@ -9,7 +9,8 @@ import { useEffect, useState, useRef } from 'react';
 
 import './index.css';
 
-const drawerWidth = '30rem';
+const drawerWidth = '25vw';
+const drawerMinWidth = '300px';
 const Main = styledmui('main', {
   shouldForwardProp: (prop) => prop !== 'open',
 })(({ theme }) => ({
@@ -119,14 +120,16 @@ export function PersistentDrawerRight({
       <Drawer
         sx={{
           width: drawerWidth,
+          minWidth: drawerMinWidth,
           marginRight: '5px',
           marginTop: '5px',
           flexShrink: 0,
           '& .MuiDrawer-paper': {
+            minWidth: drawerMinWidth,
             width: drawerWidth,
             marginRight: '5px',
             marginTop: '5px',
-            height: 'calc(100vh - var(--colorbar-height) - 3.5%)', //colobar is up 3% from bottom
+            height: 'calc(100vh - var(--colorbar-height) - 15px)', //colobar is 5px from bottom and drawer is 5px from top
             borderRadius: '3px',
           },
         }}

--- a/src/components/ui/loading/index.jsx
+++ b/src/components/ui/loading/index.jsx
@@ -1,8 +1,8 @@
 import { Oval } from 'react-loader-spinner';
 
 export function LoadingSpinner() {
-  let loadingColor = '#082A63';
-  let loadingBackgroundColor = '#2C3E50';
+  let loadingColor = 'var(--ghg-indigo)';
+  let loadingBackgroundColor = 'var(--light-grey)';
   return (
     <Oval
       color={loadingColor}

--- a/src/components/ui/title/index.jsx
+++ b/src/components/ui/title/index.jsx
@@ -33,3 +33,4 @@ export const Title = ({ title, description }) => {
     </>
   );
 };
+

--- a/src/components/ui/toggle/index.css
+++ b/src/components/ui/toggle/index.css
@@ -2,19 +2,18 @@
   width: 100%;
   display: flex;
   justify-content: space-between;
-  color:var(--main-blue);
+  color: var(--ghg-indigo);
   font-size: 18px;
 }
 
 .custom-label-cov {
   font-size: 17px;
   padding-top: 0px;
-  color:var(--main-blue);
+  color: var(--ghg-indigo);
   font-weight: 550;
 }
 
 .toggle-switch {
-  margin-right: 15px;
   position: relative;
   display: inline-block;
   width: 40px;
@@ -36,56 +35,70 @@
   right: 0;
   bottom: 0;
   background-color: rgba(8, 42, 100, 0.3);
-  border-radius: 10px; /* Adjust for smaller size */
+  border-radius: 10px;
+  /* Adjust for smaller size */
   transition: 0.4s;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 4px; /* Adjust padding */
+  padding: 0 4px;
+  /* Adjust padding */
   box-sizing: border-box;
 }
+
 .slider:after {
   content: 'ON';
   color: white;
   font-size: 12px;
   font-weight: bold;
-  opacity: 0; /* Hidden by default */
+  opacity: 0;
+  /* Hidden by default */
 }
+
 /* Slider round circle */
 .slider::before {
   content: '';
-  height: 14px; /* Smaller circle */
-  width: 14px; /* Smaller circle */
+  height: 14px;
+  /* Smaller circle */
+  width: 14px;
+  /* Smaller circle */
   border-radius: 50%;
   background-color: white;
   box-shadow: 0px 1px 5px rgba(0, 0, 0, 0.3);
   position: absolute;
   bottom: 3px;
-  left: 3px; /* Adjust for smaller size */
+  left: 3px;
+  /* Adjust for smaller size */
   transition: 0.4s;
 }
+
 /* "ON" Text */
 .slider::after {
   content: 'ON';
   z-index: inherit;
   color: white;
-  font-size: 10px; /* Smaller font size */
+  font-size: 10px;
+  /* Smaller font size */
   font-weight: bold;
   position: absolute;
-  right: 8px; /* Adjust position for smaller toggle */
-  opacity: 0; /* Hidden by default */
+  right: 8px;
+  /* Adjust position for smaller toggle */
+  opacity: 0;
+  /* Hidden by default */
   transition: 0.4s;
 }
 
 /* When checked, move the slider background */
-input:checked + .slider {
-  background-color: #082a63;
+input:checked+.slider {
+  background-color: var(--ghg-indigo);
 }
 
-input:checked + .slider::before {
-  transform: translateX(20px); /* Adjust based on new width */
+input:checked+.slider::before {
+  transform: translateX(20px);
+  /* Adjust based on new width */
 }
-input:checked + .slider::after {
+
+input:checked+.slider::after {
   opacity: 1;
   left: 4px;
 }

--- a/src/components/ui/toggle/index.jsx
+++ b/src/components/ui/toggle/index.jsx
@@ -16,7 +16,7 @@ import './index.css';
  * @returns {JSX.Element}
  */
 
-export const  ToggleSwitch = ({ title, onToggle, enabled, initialState }) => {
+export const ToggleSwitch = ({ title, onToggle, enabled, initialState }) => {
   const [isChecked, setIsChecked] = useState(false);
 
   useEffect(() => {
@@ -33,7 +33,7 @@ export const  ToggleSwitch = ({ title, onToggle, enabled, initialState }) => {
 
   return (
     <div className='toggle-container'>
-      <Typography   sx={{ fontSize:"14px",color:"grey" }} variant='body2' gutterBottom>
+      <Typography sx={{ fontSize: "14px", color: "grey" }} variant='body2' gutterBottom>
         {title}
       </Typography>
       <label className='toggle-switch'>

--- a/src/context/mapContext/index.js
+++ b/src/context/mapContext/index.js
@@ -48,8 +48,8 @@ export const MapboxProvider = ({ children }) => {
       map.current = new mapboxgl.Map({
         container: mapContainer.current,
         style: mapboxStyleUrl,
-        center: [-98.771556, 32.967243], // Centered on the US
-        zoom: 4,
+        center: [0, 0],
+        zoom: 0,
         projection: 'equirectangular',
         options: {
           trackResize: true,

--- a/src/pages/dashboard/index.css
+++ b/src/pages/dashboard/index.css
@@ -40,6 +40,7 @@
   border-radius: 5px;
   z-index: 1000;
 }
+
 .map-icon {
   color: #ffffff;
 }
@@ -50,6 +51,7 @@ button.measure-icon {
   align-items: center;
   color: #000000;
 }
+
 button.change-unit {
   display: flex;
   font-size: medium;
@@ -57,12 +59,14 @@ button.change-unit {
   align-items: center;
   color: #000000;
 }
+
 button.clear-icon {
   display: flex;
   transform: rotate(90deg);
   align-items: center;
   color: #000000;
 }
+
 button.menu-open-icon {
   display: flex;
   align-items: center;
@@ -75,6 +79,5 @@ button.menu-open-icon {
   width: 40vw;
   max-width: 400px;
   min-width: 200px;
-  padding-bottom: 10px;
-  z-index: 100000;
+  z-index: 10001;
 }

--- a/src/pages/dashboard/index.css
+++ b/src/pages/dashboard/index.css
@@ -67,3 +67,14 @@ button.menu-open-icon {
   display: flex;
   align-items: center;
 }
+
+.dashboard-title-container {
+  position: absolute;
+  top: 5px;
+  left: 5px;
+  width: 40vw;
+  max-width: 430px;
+  min-width: 250px;
+  padding-bottom: 10px;
+  z-index: 100000;
+}

--- a/src/pages/dashboard/index.css
+++ b/src/pages/dashboard/index.css
@@ -73,8 +73,8 @@ button.menu-open-icon {
   top: 5px;
   left: 5px;
   width: 40vw;
-  max-width: 430px;
-  min-width: 250px;
+  max-width: 400px;
+  min-width: 200px;
   padding-bottom: 10px;
   z-index: 100000;
 }

--- a/src/pages/dashboard/index.css
+++ b/src/pages/dashboard/index.css
@@ -80,4 +80,12 @@ button.menu-open-icon {
   max-width: 400px;
   min-width: 200px;
   z-index: 10001;
+  container-type: inline-size;
+  container-name: title-container;
+}
+
+@container title-container (width < 215px) {
+  .accordion-title {
+    font-size: 1rem !important;
+  }
 }

--- a/src/pages/dashboard/index.jsx
+++ b/src/pages/dashboard/index.jsx
@@ -208,34 +208,73 @@ export function Dashboard({
     <div className='fullSize'>
       <div id='dashboard-map-container'>
         <MainMap>
-          <Paper className='title-container'>
-            <Title title={TITLE} description={DESCRIPTION} />
-            <div className='title-content'>
-              <HorizontalLayout>
-                <Search
-                  setFromSearch={setFromSearch}
-                  vizItems={Object.keys(filteredVizItems).map(
-                    (key) => filteredVizItems[key]
-                  )}
-                  onSelectedVizItemSearch={handleSelectedVizItemSearch}
-                ></Search>
-              </HorizontalLayout>
-              <HorizontalLayout>
-                <FilterByDate
-                  filterDateRange={filterDateRange}
-                  onDateChange={handleDateRangeChange}
-                />
-              </HorizontalLayout>
-              <HorizontalLayout>
-                <ToggleSwitch
-                  title={'Show EMIT Coverage'}
-                  onToggle={handleCoverageToggle}
-                  initialState={showCoverage}
-                  enabled={enableToggle}
-                />
-              </HorizontalLayout>
-            </div>
-          </Paper>
+          <div className='dashboard-title-container'>
+            <Accordion sx={{ position: 'relative', zIndex: 1 }}>
+              <AccordionSummary
+                expandIcon={<ExpandMoreIcon />}
+                sx={{
+                  minHeight: '48px',
+                  '&.Mui-expanded': {
+                    minHeight: '48px',
+                  },
+                  '& .MuiAccordionSummary-content': {
+                    margin: '12px 0',
+                  },
+                  '& .MuiAccordionSummary-content.Mui-expanded': {
+                    margin: '12px 0',
+                  },
+                }}
+              >
+                <Typography
+                  variant='h5'
+                  component='div'
+                  fontWeight='bold'
+                  color='var(--main-grey)'
+                  sx={{ padding: '0 10px' }}
+                >
+                  {TITLE}
+                </Typography>
+              </AccordionSummary>
+              <AccordionDetails
+                sx={{ margin: '0 12px', padding: '0', maxHeight: '70vh', overflowY: 'auto', position: 'relative', zIndex: 1 }}
+              >
+                {DESCRIPTION && (
+                  <Typography
+                    variant='body2'
+                    component='div'
+                    color='text.secondary'
+                    sx={{ marginBottom: '1rem', padding: '0 0.9rem' }}
+                  >
+                    {DESCRIPTION}
+                  </Typography>)}
+                <div className='title-content'>
+                  <HorizontalLayout>
+                    <Search
+                      setFromSearch={setFromSearch}
+                      vizItems={Object.keys(filteredVizItems).map(
+                        (key) => filteredVizItems[key]
+                      )}
+                      onSelectedVizItemSearch={handleSelectedVizItemSearch}
+                    ></Search>
+                  </HorizontalLayout>
+                  <HorizontalLayout>
+                    <FilterByDate
+                      filterDateRange={filterDateRange}
+                      onDateChange={handleDateRangeChange}
+                    />
+                  </HorizontalLayout>
+                  <HorizontalLayout>
+                    <ToggleSwitch
+                      title={'Show EMIT Coverage'}
+                      onToggle={handleCoverageToggle}
+                      initialState={showCoverage}
+                      enabled={enableToggle}
+                    />
+                  </HorizontalLayout>
+                </div>
+              </AccordionDetails>
+            </Accordion>
+          </div>
           <MapZoom zoomLocation={zoomLocation} zoomLevel={zoomLevel} />
           <MapControls
             openDrawer={openDrawer}

--- a/src/pages/dashboard/index.jsx
+++ b/src/pages/dashboard/index.jsx
@@ -247,6 +247,7 @@ export function Dashboard({
                   component='div'
                   fontWeight='bold'
                   color='var(--main-grey)'
+                  className='accordion-title'
                   sx={{ padding: '0 10px' }}
                 >
                   {TITLE}

--- a/src/pages/dashboard/index.jsx
+++ b/src/pages/dashboard/index.jsx
@@ -75,7 +75,7 @@ export function Dashboard({
   setZoomLevel,
   collectionId,
   loadingData,
-  isEmbeded,
+  isEmbedded,
 }) {
   // states for data
   const [vizItems, setVizItems] = useState([]); // store all available visualization items
@@ -89,9 +89,20 @@ export function Dashboard({
   const [enableToggle, setEnableToggle] = useState(false);
   const [fromSearch, setFromSearch] = useState(false);
 
-  // states for components/controls
-  const [openDrawer, setOpenDrawer] = useState(false);
+  // state for displaying colorbar legend
   const [showLegend, setShowLegend] = useState(true);
+
+  // state for right drawer
+  const [internalOpenDrawer, setInternalOpenDrawer] = useState(false);
+  const openDrawer = isEmbedded ? false : internalOpenDrawer;
+  //  set drawer to open only when it is not embeded
+  const setOpenDrawer = useCallback((isOpen) => {
+    if (isOpen && (isEmbedded || !visualizationLayers?.length)) {
+      return;
+    }
+    setInternalOpenDrawer(isOpen);
+  }, [isEmbedded, visualizationLayers]);
+
 
   const { config } = useConfig();
 
@@ -101,7 +112,7 @@ export function Dashboard({
   const [colormap, setColormap] = useState('plasma');
   const [assets, setAssets] = useState('ch4-plume-emissions');
 
-  const expandAccordion = isEmbeded ? false : true;
+  const expandAccordion = isEmbedded ? false : true;
 
   // handler functions
   const handleSelectedVizItem = (vizItemId) => {

--- a/src/pages/dashboard/index.jsx
+++ b/src/pages/dashboard/index.jsx
@@ -93,8 +93,16 @@ export function Dashboard({
   const [showLegend, setShowLegend] = useState(true);
 
   // state for right drawer
+  const [drawerActive, setDrawerActive] = useState(false);
   const [internalOpenDrawer, setInternalOpenDrawer] = useState(false);
   const openDrawer = isEmbedded ? false : internalOpenDrawer;
+
+  // Update drawerActive based on conditions: not embedded AND has visualization layers
+  useEffect(() => {
+    const isActive = !isEmbedded && visualizationLayers?.length > 0;
+    setDrawerActive(isActive);
+  }, [isEmbedded, visualizationLayers]);
+
   //  set drawer to open only when it is not embeded
   const setOpenDrawer = useCallback((isOpen) => {
     if (isOpen && (isEmbedded || !visualizationLayers?.length)) {
@@ -313,6 +321,7 @@ export function Dashboard({
           </div>
           <MapZoom zoomLocation={zoomLocation} zoomLevel={zoomLevel} />
           <MapControls
+            isDrawerActive={drawerActive}
             openDrawer={openDrawer}
             setOpenDrawer={setOpenDrawer}
             handleResetHome={handleResetHome}

--- a/src/pages/dashboard/index.jsx
+++ b/src/pages/dashboard/index.jsx
@@ -75,6 +75,7 @@ export function Dashboard({
   setZoomLevel,
   collectionId,
   loadingData,
+  isEmbeded,
 }) {
   // states for data
   const [vizItems, setVizItems] = useState([]); // store all available visualization items
@@ -99,6 +100,8 @@ export function Dashboard({
   const [VMIN, setVMIN] = useState(-92);
   const [colormap, setColormap] = useState('plasma');
   const [assets, setAssets] = useState('ch4-plume-emissions');
+
+  const expandAccordion = isEmbeded ? false : true;
 
   // handler functions
   const handleSelectedVizItem = (vizItemId) => {
@@ -220,7 +223,10 @@ export function Dashboard({
       <div id='dashboard-map-container'>
         <MainMap>
           <div className='dashboard-title-container'>
-            <Accordion sx={{ position: 'relative', zIndex: 1 }}>
+            <Accordion
+              sx={{ position: 'relative', zIndex: 1 }}
+              defaultExpanded={expandAccordion}
+            >
               <AccordionSummary
                 expandIcon={<ExpandMoreIcon />}
                 sx={{

--- a/src/pages/dashboard/index.jsx
+++ b/src/pages/dashboard/index.jsx
@@ -31,17 +31,19 @@ import moment from 'moment';
 import { useConfig } from '../../context/configContext';
 
 const TITLE = 'EMIT Methane Plume Viewer';
+
 const DESCRIPTION =
   'Using a special technique, the EMIT hyperspectral data\
    is used to visualize large methane plumes whenever the instrument \
    observes the surface. Due to variations of the International Space Station orbit,\
    EMIT does not have a regular observation repeat cycle.';
+
 const HorizontalLayout = styled.div`
   width: 90%;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  margin: 12px;
+  margin: 12px 12px 0 12px;
 `;
 
 /**
@@ -239,7 +241,14 @@ export function Dashboard({
                 </Typography>
               </AccordionSummary>
               <AccordionDetails
-                sx={{ margin: '0 12px', padding: '0', maxHeight: '70vh', overflowY: 'auto', position: 'relative', zIndex: 1 }}
+                sx={{
+                  margin: '0 12px',
+                  padding: '0 0 20px 0',
+                  maxHeight: '70vh',
+                  overflowY: 'auto',
+                  position: 'relative',
+                  zIndex: 1
+                }}
               >
                 {DESCRIPTION && (
                   <Typography

--- a/src/pages/dashboard/index.jsx
+++ b/src/pages/dashboard/index.jsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useState, useRef, useCallback } from 'react';
-import Box from '@mui/material/Box';
-import Paper from '@mui/material/Paper';
+import Accordion from '@mui/material/Accordion';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import Typography from '@mui/material/Typography';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
 import {
   MainMap,

--- a/src/pages/dashboard/index.jsx
+++ b/src/pages/dashboard/index.jsx
@@ -90,6 +90,7 @@ export function Dashboard({
 
   // states for components/controls
   const [openDrawer, setOpenDrawer] = useState(false);
+  const [showLegend, setShowLegend] = useState(true);
 
   const { config } = useConfig();
 
@@ -110,6 +111,7 @@ export function Dashboard({
     setZoomLocation([lon, lat]);
     setZoomLevel(RASTER_ZOOM_LEVEL); // take the default zoom level
     setOpenDrawer(true);
+    setShowLegend(true);
   };
 
   const handleClickedVizLayer = (vizLayerId) => {
@@ -134,6 +136,7 @@ export function Dashboard({
     setZoomLocation(location);
     setZoomLevel(RASTER_ZOOM_LEVEL);
     setOpenDrawer(true);
+    setShowLegend(true);
   };
   const filterVizItems = (dateRange, vizItems) => {
     const allVizItems = Object.keys(vizItems)?.map((key) => vizItems[key]);
@@ -153,6 +156,7 @@ export function Dashboard({
     setFromSearch(false);
     setVisualizationLayers([]);
     setOpenDrawer(false);
+    setShowLegend(false);
     setZoomLevel(4);
     setZoomLocation([-98.771556, 32.967243]);
   };
@@ -187,8 +191,10 @@ export function Dashboard({
   useEffect(() => {
     if (visualizationLayers?.length) {
       setOpenDrawer(true);
+      setShowLegend(true);
     } else {
       setOpenDrawer(false);
+      setShowLegend(false);
     }
   }, [JSON.stringify(visualizationLayers)]);
 
@@ -343,7 +349,7 @@ export function Dashboard({
         />
         )
       </div>
-      {VMAX && (
+      {VMAX && showLegend && (
         <ColorBar
           label={'Methane Enhancement (ppm m)'}
           VMAX={VMAX}

--- a/src/pages/dashboardContainer/index.jsx
+++ b/src/pages/dashboardContainer/index.jsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useState, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
 import { Dashboard } from '../dashboard/index.jsx';
 import {
   fetchCollectionMetadata,
@@ -32,6 +34,8 @@ export const DashboardContainer = ({
   defaultZoomLevel,
   defaultStartDate,
 }) => {
+  // get the query params
+  const [searchParams] = useSearchParams();
   const { config } = useConfig();
   const [coverage, setCoverage] = useState();
   const [zoomLocation, setZoomLocation] = useState(defaultZoomLocation);
@@ -40,6 +44,7 @@ export const DashboardContainer = ({
   const [plumes, setPlumes] = useState([]);
   const [loadingData, setLoadingData] = useState(true);
   const [filterDateRange, setFilterDateRange] = useState({});
+  const isEmbeded = searchParams.get('embeded') === 'true' || false;
 
   // Fetch collection metadata and plumes data
   useEffect(() => {
@@ -130,6 +135,7 @@ export const DashboardContainer = ({
       filterDateRange={filterDateRange}
       collectionId={collectionId}
       loadingData={loadingData}
+      isEmbeded={isEmbeded}
     />
   );
 };

--- a/src/pages/dashboardContainer/index.jsx
+++ b/src/pages/dashboardContainer/index.jsx
@@ -44,7 +44,7 @@ export const DashboardContainer = ({
   const [plumes, setPlumes] = useState([]);
   const [loadingData, setLoadingData] = useState(true);
   const [filterDateRange, setFilterDateRange] = useState({});
-  const isEmbeded = searchParams.get('embeded') === 'true' || false;
+  const isEmbedded = searchParams.get('embed') === 'true' || false;
 
   // Fetch collection metadata and plumes data
   useEffect(() => {
@@ -135,7 +135,7 @@ export const DashboardContainer = ({
       filterDateRange={filterDateRange}
       collectionId={collectionId}
       loadingData={loadingData}
-      isEmbeded={isEmbeded}
+      isEmbedded={isEmbedded}
     />
   );
 };

--- a/src/pages/dashboardContainer/index.jsx
+++ b/src/pages/dashboardContainer/index.jsx
@@ -37,14 +37,16 @@ export const DashboardContainer = ({
   // get the query params
   const [searchParams] = useSearchParams();
   const { config } = useConfig();
+  const isEmbedded = searchParams.get('embed') === 'true';
   const [coverage, setCoverage] = useState();
-  const [zoomLocation, setZoomLocation] = useState(defaultZoomLocation);
-  const [zoomLevel, setZoomLevel] = useState(defaultZoomLevel);
+  const [zoomLocation, setZoomLocation] = useState(
+    isEmbedded ? [-40, 5] : defaultZoomLocation
+  );
+  const [zoomLevel, setZoomLevel] = useState(isEmbedded ? 1 : defaultZoomLevel);
   const [collectionMeta, setCollectionMeta] = useState({});
   const [plumes, setPlumes] = useState([]);
   const [loadingData, setLoadingData] = useState(true);
   const [filterDateRange, setFilterDateRange] = useState({});
-  const isEmbedded = searchParams.get('embed') === 'true' || false;
 
   // Fetch collection metadata and plumes data
   useEffect(() => {


### PR DESCRIPTION
Requirements
--
The web team has added the EMIT Plume Viewer in a smaller window on the ["Global" page in Portal 2.0](https://staging.earth.gov/ghgcenter/global). The PO has confirmed we can collapse the "EMIT Methane Plume Viewer" intro/search/date box in the top left. The legend should also be collapsible.

Overview
--
Embed mode: https://dev.ghg.center/ghgcenter/data-tools/view/emit-plume-viewerpr-preview-30?embed=true
- Make title card collapsible
- Hide right drawer in embed mode
- Hide map legend when no active viz item
- Make UI elements dynamic

Visual Changes
--
* Adopted ghg-indigo as the highlight color.
* Map marker color slightly muted/less saturated

**Title Card** 
* Title card is now collapsible, showing only the title when collapsed.
* Slightly reduced search box size (dimensions + font).
* Responsive sizing based on screen dimensions.

**Legend**
* Slightly reduced legend size.
* Legend is shown only when one or more plumes are active (in both embed and normal modes).
* Responsive sizing based on screen dimensions.

**Right Drawer**
* Fully disabled in embed mode (greyed-out icon + “Drawer unavailable” tooltip).
* Disabled in normal mode when no plumes are active (greyed-out icon and similar tooltip).
* Plume details card switches layout on smaller screens (image moves above details). Changed font color and size to make it cleaner
* Responsive sizing based on screen dimensions.

Closes: US-GHG-Center/ghgc-architecture#826