### PR TITLE
Fix: measurement tool cursor reset

### DIFF
--- a/src/components/map/measurementLayer/index.jsx
+++ b/src/components/map/measurementLayer/index.jsx
@@ -123,7 +123,6 @@ export const MeasurementLayer = ({
    * Handles activation and deactivation of layers, sources, and cursor style.
    */
   useEffect(() => {
-    if (!map || !map.isStyleLoaded()) return;
     if (map) {
       changeCursor(map, measurePoints, measureMode);
       if (measureMode) {


### PR DESCRIPTION
# Description:

When you select the measurement tool, the cursor seems to stay “+” instead of changing back to the little pointer hand (even when you unselect the tool)

# Change:
- allow change cursor trigger on any map and measure mode changes.